### PR TITLE
add responders and headers

### DIFF
--- a/unix/client.ml
+++ b/unix/client.ml
@@ -701,6 +701,14 @@ and dispatch_message c = function
       headers = None;
       payload = msg.Msg.payload;
     }
+  | ServerMessage.HMsg msg ->
+    Subscriptions.handle_msg c.subscriptions {
+      subject = msg.subject;
+      reply   = msg.reply;
+      sid     = int_of_string msg.sid;
+      headers = Some msg.headers;
+      payload = msg.payload;
+    }
   | ServerMessage.Ping ->
     send_msg c ClientMessage.Pong
   | ServerMessage.Pong ->
@@ -711,7 +719,6 @@ and dispatch_message c = function
   | ServerMessage.Err msg ->
     process_err c msg
   | ServerMessage.Ok -> ()
-  | _ -> ()
 
 (** [msg_loop c] processes incoming messages for the client [c].
 

--- a/unix/client.ml
+++ b/unix/client.ml
@@ -24,6 +24,7 @@ let default_inbox_prefix = "_INBOX"
 let default_ping_interval = 120.       (* in seconds *)
 let default_max_pings_outstanding = 2
 let default_no_responders = false
+let default_headers = false
 
 type callback = Subscription.callback
 
@@ -806,14 +807,19 @@ let subscribe c ?group ?callback subject =
   send_msg c sub_msg;
   sub
 
-let publish c ?reply subject payload =
+let publish c ?(headers=[]) ?reply subject payload =
   if is_closed c then
     nats_error ConnectionClosed;
 
-  let pub_msg = ClientMessage.Pub (Pub.make ~subject ?reply ~payload ()) in
+  let pub_msg = match headers with
+    | [] -> ClientMessage.Pub (Pub.make ~subject ?reply ~payload ())
+    | _ ->
+      let headers = Nats.Protocol.Headers.make ~headers () in
+      ClientMessage.HPub (HPub.make ~headers ~subject ?reply ~payload ())
+  in
   send_msg c pub_msg
 
-let request c ?timeout subject payload =
+let request c ?headers ?timeout subject payload =
   if is_closed c then
     nats_error ConnectionClosed;
 
@@ -832,7 +838,7 @@ let request c ?timeout subject payload =
       Fun.protect
         ~finally:(fun () -> Mutex.protect c.mutex (fun () -> c.cur_request <- None))
         begin fun () ->
-          publish c ~reply:resp_subject subject payload;
+          publish c ?headers ~reply:resp_subject subject payload;
 
           match PendingRequest.wait req with
           | Response msg  -> msg
@@ -840,9 +846,9 @@ let request c ?timeout subject payload =
         end
     end
 
-let request_opt c ?timeout subject payload =
+let request_opt c ?headers ?timeout subject payload =
   try
-    Some (request c subject payload ?timeout)
+    Some (request c ?headers subject payload ?timeout)
   with NatsError Timeout ->
     None
 
@@ -897,8 +903,14 @@ let process_expected_info ?timeout c =
 
 (** [send_connect ?timeout c] sends a CONNECT protocol message to the server
     and waits for a flush to return from the server for error processing. *)
-let send_connect ?(no_responders=false) ?timeout c =
+let send_connect
+    ?(no_responders=default_no_responders)
+    ?(headers=default_headers)
+    ?timeout c =
   let remaining_time = remaining_time_fn timeout in
+
+  (* no responders requires headers *)
+  let headers = headers || no_responders in
 
   let connect_msg = ClientMessage.Connect
       (Connect.make
@@ -911,7 +923,7 @@ let send_connect ?(no_responders=false) ?timeout c =
          ~tls_required:false
          ~echo:true
          ~no_responders
-         ~headers:false
+         ~headers
          ())
   in
   send_msg_direct c connect_msg;
@@ -937,7 +949,8 @@ let connect
     ?connect_timeout
     ?(ping_interval = default_ping_interval)
     ?(max_pings_outstanding = default_max_pings_outstanding)
-    ?(no_responders=default_no_responders)
+    ?(no_responders = default_no_responders)
+    ?(headers=default_headers)
     ?(closed_cb = Fun.const ())
     ?(error_cb = default_error_callback)
     ?(inbox_prefix = default_inbox_prefix)
@@ -999,7 +1012,7 @@ let connect
   begin
     try
       process_expected_info conn ?timeout:(remaining_time ());
-      send_connect conn ~no_responders ?timeout:(remaining_time ());
+      send_connect conn ~headers ~no_responders ?timeout:(remaining_time ());
 
       ignore @@ subscribe conn (conn.resp_sub_prefix ^ "*")
         ~callback:begin fun msg ->

--- a/unix/client.ml
+++ b/unix/client.ml
@@ -23,6 +23,7 @@ let default_inbox_prefix = "_INBOX"
 
 let default_ping_interval = 120.       (* in seconds *)
 let default_max_pings_outstanding = 2
+let default_no_responders = false
 
 type callback = Subscription.callback
 
@@ -369,6 +370,7 @@ type t = {
   (** The subscription manager for handling active subscriptions. *)
   cur_sync_op : CurrentSyncOperation.t;
   (** The current synchronous operation being executed. *)
+  (* TODO: replace with a hashmap nuid -> request *)
   mutable cur_request : PendingRequest.t option;
   (** The current pending request, if any. *)
   ping_pongs : PingPongTracker.t;
@@ -895,7 +897,7 @@ let process_expected_info ?timeout c =
 
 (** [send_connect ?timeout c] sends a CONNECT protocol message to the server
     and waits for a flush to return from the server for error processing. *)
-let send_connect ?timeout c =
+let send_connect ?(no_responders=false) ?timeout c =
   let remaining_time = remaining_time_fn timeout in
 
   let connect_msg = ClientMessage.Connect
@@ -908,7 +910,7 @@ let send_connect ?timeout c =
          ~pedantic:c.options.pedantic
          ~tls_required:false
          ~echo:true
-         ~no_responders:false
+         ~no_responders
          ~headers:false
          ())
   in
@@ -935,6 +937,7 @@ let connect
     ?connect_timeout
     ?(ping_interval = default_ping_interval)
     ?(max_pings_outstanding = default_max_pings_outstanding)
+    ?(no_responders=default_no_responders)
     ?(closed_cb = Fun.const ())
     ?(error_cb = default_error_callback)
     ?(inbox_prefix = default_inbox_prefix)
@@ -996,7 +999,7 @@ let connect
   begin
     try
       process_expected_info conn ?timeout:(remaining_time ());
-      send_connect conn ?timeout:(remaining_time ());
+      send_connect conn ~no_responders ?timeout:(remaining_time ());
 
       ignore @@ subscribe conn (conn.resp_sub_prefix ^ "*")
         ~callback:begin fun msg ->

--- a/unix/client.mli
+++ b/unix/client.mli
@@ -57,6 +57,7 @@ val connect :
   ?ping_interval:float ->
   ?max_pings_outstanding:int ->
   ?no_responders:bool ->
+  ?headers:bool ->
   ?closed_cb:conn_callback ->
   ?error_cb:error_callback ->
   ?inbox_prefix:string ->
@@ -79,6 +80,7 @@ val connect :
       seconds.
     - [ping_interval] (optional): the period (in seconds) at which the client
       will be sending PING commands to the server.  Defaults to 120 seconds.
+    - [headers] (optional): enable support for headers. Defaults to false.
     - [no_responders] (optional): if true, requests with no subscribers fail
       with a "no responders" error. Defaults to false.
     - [max_pings_outstanding] (optional): the maximum number of pending PING
@@ -158,7 +160,7 @@ val subscribe : t -> ?group:string -> ?callback:callback -> string -> Subscripti
     with an optional reply-to subject.
 
     Raises [NatsError ConnectionClosed] if the connection is closed. *)
-val publish : t -> ?reply:string -> string -> string -> unit
+val publish : t -> ?headers:(string*string) list -> ?reply:string -> string -> string -> unit
 
 (** [request t ?timeout subject payload] sends a request message to the given
     subject and waits for a reply within an optional timeout period.
@@ -170,7 +172,7 @@ val publish : t -> ?reply:string -> string -> string -> unit
       operation.
     - [NatsError Timeout] if the request times out.
 *)
-val request : t -> ?timeout:float -> string -> string -> Nats.Message.t
+val request : t -> ?headers:(string*string) list -> ?timeout:float -> string -> string -> Nats.Message.t
 
 (** [request_opt t ?timeout subject payload] sends a request message to the
     given subject and waits for a reply within an optional timeout period.
@@ -182,7 +184,7 @@ val request : t -> ?timeout:float -> string -> string -> Nats.Message.t
     - [NatsError ConnectionLost] if the connection is lost during the
       operation.
 *)
-val request_opt : t -> ?timeout:float -> string -> string -> Nats.Message.t option
+val request_opt : t -> ?headers:(string*string) list -> ?timeout:float -> string -> string -> Nats.Message.t option
 
 (** [flush ?timeout t] performs a round trip to the server and returns when it
     receives the internal reply, or if the call times-out ([timeout] is

--- a/unix/client.mli
+++ b/unix/client.mli
@@ -56,6 +56,7 @@ val connect :
   ?connect_timeout:float ->
   ?ping_interval:float ->
   ?max_pings_outstanding:int ->
+  ?no_responders:bool ->
   ?closed_cb:conn_callback ->
   ?error_cb:error_callback ->
   ?inbox_prefix:string ->
@@ -78,6 +79,8 @@ val connect :
       seconds.
     - [ping_interval] (optional): the period (in seconds) at which the client
       will be sending PING commands to the server.  Defaults to 120 seconds.
+    - [no_responders] (optional): if true, requests with no subscribers fail
+      with a "no responders" error. Defaults to false.
     - [max_pings_outstanding] (optional): the maximum number of pending PING
       commands that can be awaiting a response before raising a
       [StaleConnection] error.  Defaults to 2.
@@ -144,7 +147,7 @@ val new_inbox : t -> string
     the {!Subscription.next_msg} function is used to obtain the delivered
     messages.
 
-    If [queue] is given the subscription is a queue subscription.  All
+    If [group] is given the subscription is a queue subscription.  All
     subscribers with the same queue name will form the queue group and only one
     member of the group will be selected to receive any given message.
 


### PR DESCRIPTION
- **add a `no responders` option at connect time**
- **add headers in publish/request/request_opt**
